### PR TITLE
DPL-1055: Sample names in QC results

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Rabbitmq consumer for TOL data input
 
-
 ## Getting Started
 
 The following tools are required for development:
@@ -16,23 +15,22 @@ defined in the `Pipfile`:
     brew install pyenv
     pyenv install <python_version>
 ```
-        
+
 Use pipenv to install the required python packages for the application and development:
 
 ```bash
      pipenv install --dev
 ```
 
-
 ### Setting up with Docker
 
 If you want to setup a local development environment with Docker please check
 the instructions in [SETUP_DOCKER.md](SETUP_DOCKER.md)
 
-
 ## Running
 
 1. Enter the python virtual environment using:
+
 ```bash
     pipenv shell
 ```
@@ -51,7 +49,6 @@ Run the tests using pytest (flags are for verbose and exit early):
     python -m pytest -vx
 ```
 
-
 ## Deployment
 
 This project uses a Docker image as the unit of deployment. Update `.release-version` with
@@ -60,7 +57,7 @@ along with the Docker image associated to that release.
 
 ## Snappy
 
-```
+```stdout
 If when you install the dependencies and you see the following error:
 
 [pipenv.exceptions.InstallError]:       src/snappy/snappymodule.cc:33:10: fatal error: 'snappy-c.h' file not found
@@ -79,10 +76,14 @@ ERROR: Couldn't install package: {}
 
 You need to install snappy and set the path:
 
-```
+```bash
 brew install snappy
 ```
 
-```
-pip install --global-option=build_ext --global-option='-I/opt/homebrew/include' --global-option='-L/opt/homebrew/lib' python-snappy
+Ensure the `include` and `lib` directories of `homebrew` are set in environment variables.
+You might want to add these to your `~/.zshrc` file:
+
+```bash
+export CPPFLAGS="-I$(brew --prefix)/include"
+export LDFLAGS="-L$(brew --prefix)/lib"
 ```

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Use pyenv or something similar to install the version of python
 defined in the `Pipfile`:
 
 ```bash
-    brew install pyenv
-    pyenv install <python_version>
+brew install pyenv
+pyenv install <python_version>
 ```
 
 Use pipenv to install the required python packages for the application and development:
 
 ```bash
-     pipenv install --dev
+pipenv install --dev
 ```
 
 ### Setting up with Docker
@@ -31,22 +31,22 @@ the instructions in [SETUP_DOCKER.md](SETUP_DOCKER.md)
 
 1. Enter the python virtual environment using:
 
-```bash
+    ```bash
     pipenv shell
-```
+    ```
 
 1. Run the app using:
 
-```bash
+    ```bash
     python main.py
-```
+    ```
 
 ## Testing
 
 Run the tests using pytest (flags are for verbose and exit early):
 
 ```bash
-    python -m pytest -vx
+python -m pytest -vx
 ```
 
 ## Deployment
@@ -57,9 +57,9 @@ along with the Docker image associated to that release.
 
 ## Snappy
 
-```stdout
 If when you install the dependencies and you see the following error:
 
+```stdout
 [pipenv.exceptions.InstallError]:       src/snappy/snappymodule.cc:33:10: fatal error: 'snappy-c.h' file not found
 [pipenv.exceptions.InstallError]:       #include <snappy-c.h>
 [pipenv.exceptions.InstallError]:                ^~~~~~~~~~~~
@@ -74,7 +74,7 @@ ERROR: Couldn't install package: {}
  Package installation failed...
 ```
 
-You need to install snappy and set the path:
+You need to install snappy:
 
 ```bash
 brew install snappy

--- a/SETUP_DOCKER.md
+++ b/SETUP_DOCKER.md
@@ -1,47 +1,53 @@
 ## Setting up a complete development environment from scratch
 
 1. Start dependent services: RabbitMQ and RedPanda
-```bash
-  ./docker/dependencies/up.sh
-```
 
-2. Setup RabbitMQ configuration (queues, etc). You may need to wait 30 seconds from the previous command
+    ```bash
+    ./docker/dependencies/up.sh
+    ```
+
+1. Setup RabbitMQ configuration (queues, etc). You may need to wait 30 seconds from the previous command
 to run this one as it requires Rabbitmq to have started completely:
-```bash
+
+    ```bash
     python setup_dev_rabbit.py
-```
+    ```
 
-3. Load Redpanda schemas:
-```bash
+1. Load Redpanda schemas:
+
+    ```bash
     ./schemas/push.sh http://localhost:8081 redpanda-test
-```
+    ```
 
-4. Build docker image
-```bash
+1. Build docker image
+
+    ```bash
     docker build . -t tol-lab-share:develop
-```
+    ```
 
-5. Create .env file with contents
-```
-SETTINGS_MODULE=tol_lab_share.config.defaults
-LOCALHOST=host.docker.internal
-```
+1. Create .env file with contents
 
-6. Start interactive bash in docker container
-```bash
+    ```text
+    SETTINGS_MODULE=tol_lab_share.config.defaults
+    LOCALHOST=host.docker.internal
+    ```
+
+1. Start interactive bash in docker container
+
+    ```bash
     docker run -ti -v $(pwd):/code --env-file=.env --entrypoint bash tol-lab-share:develop
-```
+    ```
 
-7. Start the consumer service (inside the previous bash)
-```bash
+1. Start the consumer service (inside the previous bash)
+
+    ```bash
     pipenv run python main.py
-```
+    ```
 
 After this you should have:
 
 * Consumer (python main.py) running connected to Rabbitmq queue
 * Rabbitmq service running in http://localhost:8080/ with user/password: admin/development
 * Redpanda API service running in local in http://localhost:8081/
-
 
 If you want to perform any changes in code, you can kill the consumer with Control-C, modify the code in local and then restart the consumer again using the same command

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,32 +1,37 @@
 How to publish schemas
 ----------------------
 
+1. Ensure `jq` is installed:
+
+    ```bash
+    brew install jq
+    ```
 
 1. Run the command:
 
-```bash
-   push.sh <REDPANDA_URL> <API_KEY>
-```
+    ```bash
+    push.sh <REDPANDA_URL> <API_KEY>
+    ```
 
-where:
+    where:
 
-```
-  <REDPANDA_URL>: URL to connect to RedPanda where the schemas will be uploaded
-  <API_KEY>: secret key with write permission for redpanda
-```
+    ```text
+    <REDPANDA_URL>: URL to connect to RedPanda where the schemas will be uploaded
+    <API_KEY>: secret key with write permission for redpanda
+    ```
 
 How to remove last schemas created
 ----------------------------------
 
-1. Run the command:
+Run the command:
 
 ```bash
-   remove_all.sh <REDPANDA_URL> <API_KEY>
+remove_all.sh <REDPANDA_URL> <API_KEY>
 ```
 
 where:
 
-```
-  <REDPANDA_URL>: URL to connect to RedPanda where the schemas will be uploaded
-  <API_KEY>: secret key with write permission for redpanda
+```text
+<REDPANDA_URL>: URL to connect to RedPanda where the schemas will be uploaded
+<API_KEY>: secret key with write permission for redpanda
 ```

--- a/tests/message_properties/definitions/test_labware.py
+++ b/tests/message_properties/definitions/test_labware.py
@@ -182,7 +182,7 @@ def test_add_to_traction_qc_message(valid_sample):
     traction_qc_message = TractionQcMessage()
     instance.add_to_traction_qc_message(traction_qc_message)
 
-    assert traction_qc_message.requests(0).supplier_sample_name == "SampleSupplied1"
+    assert traction_qc_message.requests(0).sanger_sample_id == "cichlid_pacbio8196429"
     assert traction_qc_message.requests(0).container_barcode == "BARCODE001"
     assert traction_qc_message.requests(0).sheared_femto_fragment_size == "8"
     assert traction_qc_message.requests(0).post_spri_concentration == "9"

--- a/tests/messages/test_traction_qc_message.py
+++ b/tests/messages/test_traction_qc_message.py
@@ -22,7 +22,7 @@ class TestTractionQcMessage:
     @pytest.fixture()
     def valid_traction_qc_message(self):
         traction_qc_message = TractionQcMessage()
-        traction_qc_message.requests(0).supplier_sample_name = "supplier_sample_name_DDD"
+        traction_qc_message.requests(0).sanger_sample_id = "sanger_sample_id_DDD"
         traction_qc_message.requests(0).container_barcode = "FD20706500"
         traction_qc_message.requests(0).sheared_femto_fragment_size = "5"
         traction_qc_message.requests(0).post_spri_concentration = "10"
@@ -33,7 +33,7 @@ class TestTractionQcMessage:
         traction_qc_message.requests(0).shearing_qc_comments = "Comments"
         traction_qc_message.requests(0).date_submitted_utc = datetime.now().timestamp() * 1000
 
-        traction_qc_message.requests(1).supplier_sample_name = "supplier_sample_name_DDD2"
+        traction_qc_message.requests(1).sanger_sample_id = "sanger_sample_id_DDD2"
         traction_qc_message.requests(1).container_barcode = "FD20706501"
         traction_qc_message.requests(1).sheared_femto_fragment_size = "9"
         traction_qc_message.requests(1).post_spri_concentration = "10"
@@ -79,7 +79,7 @@ class TestTractionQcMessage:
                             "shearing_qc_comments": "Comments",
                             "date_submitted": datetime.now().timestamp() * 1000,
                             "labware_barcode": "FD20706500",
-                            "sample_external_id": "supplier_sample_name_DDD",
+                            "sample_external_id": "sanger_sample_id_DDD",
                         },
                         {
                             "final_nano_drop": "100",
@@ -90,7 +90,7 @@ class TestTractionQcMessage:
                             "sheared_femto_fragment_size": "9",
                             "date_submitted": datetime.now().timestamp() * 1000,
                             "labware_barcode": "FD20706501",
-                            "sample_external_id": "supplier_sample_name_DDD2",
+                            "sample_external_id": "sanger_sample_id_DDD2",
                         },
                     ],
                     "source": "tol-lab-share.tol",

--- a/tol_lab_share/message_properties/definitions/labware.py
+++ b/tol_lab_share/message_properties/definitions/labware.py
@@ -133,6 +133,4 @@ class Labware(MessageProperty):
             ).value
             traction_qc_message.requests(sample_pos).date_submitted_utc = sample.properties("date_submitted_utc").value
             traction_qc_message.requests(sample_pos).container_barcode = self.properties("barcode").value
-            traction_qc_message.requests(sample_pos).sanger_sample_id = sample.properties(
-                "sanger_sample_id"
-            ).value
+            traction_qc_message.requests(sample_pos).sanger_sample_id = sample.properties("sanger_sample_id").value

--- a/tol_lab_share/message_properties/definitions/labware.py
+++ b/tol_lab_share/message_properties/definitions/labware.py
@@ -133,6 +133,6 @@ class Labware(MessageProperty):
             ).value
             traction_qc_message.requests(sample_pos).date_submitted_utc = sample.properties("date_submitted_utc").value
             traction_qc_message.requests(sample_pos).container_barcode = self.properties("barcode").value
-            traction_qc_message.requests(sample_pos).supplier_sample_name = sample.properties(
-                "supplier_sample_name"
+            traction_qc_message.requests(sample_pos).sanger_sample_id = sample.properties(
+                "sanger_sample_id"
             ).value

--- a/tol_lab_share/messages/interfaces.py
+++ b/tol_lab_share/messages/interfaces.py
@@ -279,12 +279,12 @@ class TractionQcMessageRequestInterface:
 
     @property
     @abstractmethod
-    def supplier_sample_name(self) -> Optional[str]:
+    def sanger_sample_id(self) -> Optional[str]:
         ...
 
-    @supplier_sample_name.setter
+    @sanger_sample_id.setter
     @abstractmethod
-    def supplier_sample_name(self, value: Optional[str]) -> None:
+    def sanger_sample_id(self, value: Optional[str]) -> None:
         ...
 
     @property

--- a/tol_lab_share/messages/traction_qc_message.py
+++ b/tol_lab_share/messages/traction_qc_message.py
@@ -24,7 +24,7 @@ class TractionQcMessageRequest(TractionQcMessageRequestInterface):
 
     def __init__(self):
         """Constructor to initialize the info for the request"""
-        self._supplier_sample_name = None
+        self._sanger_sample_id = None
         self._container_barcode = None
         self._sheared_femto_fragment_size = None
         self._post_spri_concentration = None
@@ -39,7 +39,7 @@ class TractionQcMessageRequest(TractionQcMessageRequestInterface):
         """Checks that we have all required information and that it is valid before
         marking this request as valid."""
         return (
-            (self._supplier_sample_name is not None)
+            (self._sanger_sample_id is not None)
             and (self._container_barcode is not None)
             and (self._sheared_femto_fragment_size is not None)
             and (self._post_spri_concentration is not None)
@@ -62,14 +62,14 @@ class TractionQcMessageRequest(TractionQcMessageRequestInterface):
         self._container_barcode = value
 
     @property
-    def supplier_sample_name(self) -> Optional[str]:
-        """Gets the supplier sample name for this request."""
-        return self._supplier_sample_name
+    def sanger_sample_id(self) -> Optional[str]:
+        """Gets the Sanger sample id for this request."""
+        return self._sanger_sample_id
 
-    @supplier_sample_name.setter
-    def supplier_sample_name(self, value: Optional[str]) -> None:
-        """Sets the supplier sample name for this request."""
-        self._supplier_sample_name = value
+    @sanger_sample_id.setter
+    def sanger_sample_id(self, value: Optional[str]) -> None:
+        """Sets the Sanger sample id for this request."""
+        self._sanger_sample_id = value
 
     @property
     def sheared_femto_fragment_size(self) -> Optional[str]:
@@ -166,7 +166,7 @@ class QcRequestSerializer:
             "final_nano_drop_230": self.instance.final_nano_drop_230,
             "final_nano_drop": self.instance.final_nano_drop,
             "shearing_qc_comments": self.instance.shearing_qc_comments,
-            "sample_external_id": self.instance.supplier_sample_name,
+            "sample_external_id": self.instance.sanger_sample_id,
             "labware_barcode": self.instance.container_barcode,
             "date_submitted": self.instance.date_submitted_utc,
         }

--- a/tol_lab_share/messages/traction_qc_message.py
+++ b/tol_lab_share/messages/traction_qc_message.py
@@ -198,12 +198,14 @@ class TractionQcMessage(MessageProperty, TractionQcMessageInterface):
         return [self.check_has_requests, self.check_requests_have_all_content, self.check_no_errors]
 
     def requests(self, position: int) -> TractionQcMessageRequestInterface:
-        """Returns the request at position position from this message. If there is no requesrt there it
+        """Returns the request at position position from this message. If there is no request there it
         will create a new instance and return it.
-        Parameters:
-        position (int) position that we want to return
+
+        Args:
+            position (int) position that we want to return.
+
         Returns:
-        OutputTractionMessageRequest with the request required
+            TractionQcMessageRequest at the specified position.
         """
         if position not in self._requests:
             self._requests[position] = TractionQcMessageRequest()


### PR DESCRIPTION
Closes #55 

#### Changes proposed in this pull request

- QC messages for Traction pass the `sangerSampleId` for the `sample_external_id` instead of the `supplierSampleName` from the Rabbit message.
- Some tidy up of documentation and inconsistent setup instructions.

#### Instructions for Reviewers

- [ ] _[All PRs] - Confirm PR template filled_  
- [ ] _[Feature Branches] - Review code_  
- [ ] ~~_[Production Merges to `main`]_~~
    - [ ] ~~_Check story numbers included_~~  
    - [ ] ~~_Check for debug code_~~  
    - [ ] ~~_Check version_~~  
