### PR TITLE
DPL-1111: Include genome size as estimate_of_bp_required in Traction message

### DIFF
--- a/tests/messages/test_output_traction_message.py
+++ b/tests/messages/test_output_traction_message.py
@@ -41,44 +41,46 @@ def test_output_traction_message_can_generate_payload_for_plates():
     instance = OutputTractionMessage()
 
     request = instance.create_request()
+    request.accession_number = "AN1234"
     request.container_barcode = "1"
-    request.container_type = "wells"
     request.container_location = "A1"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public1"
+    request.container_type = "wells"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor1"
+    request.genome_size = "123,456,789"
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public1"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample1"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor1"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1234"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1235"
     request.container_barcode = "1"
-    request.container_type = "wells"
     request.container_location = "B1"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public2"
+    request.container_type = "wells"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor2"
+    request.genome_size = None
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public2"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample2"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor2"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1235"
-    request.date_of_sample_collection = my_date
 
     assert instance.payload() == {
         "data": {
@@ -93,45 +95,47 @@ def test_output_traction_message_can_generate_payload_for_plates():
                             {
                                 "position": "A1",
                                 "request": {
+                                    "cost_code": "S1234",
+                                    "estimate_of_gb_required": "123,456,789",
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S1234",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1234",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor1",
                                     "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample1",
                                     "public_name": "Public1",
+                                    "sanger_sample_id": "sample1",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier1",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor1",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1234",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                             {
                                 "position": "B1",
                                 "request": {
+                                    "cost_code": "S4567",
+                                    "estimate_of_gb_required": None,
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S4567",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1235",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor2",
                                     "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample2",
                                     "public_name": "Public2",
+                                    "sanger_sample_id": "sample2",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier2",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor2",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1235",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                         ],
@@ -152,87 +156,91 @@ def test_output_traction_message_can_generate_payload_for_multiple_plates():
 
     # First plate, first well (A1).
     request = instance.create_request()
+    request.accession_number = "AN1234"
     request.container_barcode = "123"
-    request.container_type = "wells"
     request.container_location = "A1"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1234-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public1"
+    request.container_type = "wells"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor1"
+    request.genome_size = "123,456,789"
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public1"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-1234-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample1"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor1"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1234"
-    request.date_of_sample_collection = my_date
 
     # Second plate, first well (B1).
     request = instance.create_request()
+    request.accession_number = "AN1236"
     request.container_barcode = "456"
-    request.container_type = "wells"
     request.container_location = "B1"
-    request.library_type = "library"
-    request.sample_name = "test3"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1236-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public3"
+    request.container_type = "wells"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor3"
+    request.genome_size = None
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public3"
+    request.sample_name = "test3"
+    request.sample_uuid = "8860a6b4-1236-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample3"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor3"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1236"
-    request.date_of_sample_collection = my_date
 
     # First plate, second well (B1).
     request = instance.create_request()
+    request.accession_number = "AN1235"
     request.container_barcode = "123"
-    request.container_type = "wells"
     request.container_location = "B1"
-    request.library_type = "library"
-    request.sample_name = "test2"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1235-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public2"
+    request.container_type = "wells"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor2"
+    request.genome_size = None
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public2"
+    request.sample_name = "test2"
+    request.sample_uuid = "8860a6b4-1235-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample2"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor2"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1235"
-    request.date_of_sample_collection = my_date
 
     # Second plate, second well (C1).
     request = instance.create_request()
+    request.accession_number = "AN1237"
     request.container_barcode = "456"
-    request.container_type = "wells"
     request.container_location = "C1"
-    request.library_type = "library"
-    request.sample_name = "test4"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1237-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public4"
+    request.container_type = "wells"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor4"
+    request.genome_size = "987,654,321"
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public4"
+    request.sample_name = "test4"
+    request.sample_uuid = "8860a6b4-1237-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample4"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor4"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1237"
-    request.date_of_sample_collection = my_date
 
     assert instance.payload() == {
         "data": {
@@ -247,45 +255,47 @@ def test_output_traction_message_can_generate_payload_for_multiple_plates():
                             {
                                 "position": "A1",
                                 "request": {
+                                    "cost_code": "S1234",
+                                    "estimate_of_gb_required": "123,456,789",
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S1234",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1234",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor1",
                                     "external_id": "8860a6b4-1234-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample1",
                                     "public_name": "Public1",
+                                    "sanger_sample_id": "sample1",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier1",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor1",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1234",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                             {
                                 "position": "B1",
                                 "request": {
+                                    "cost_code": "S4567",
+                                    "estimate_of_gb_required": None,
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S4567",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1235",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor2",
                                     "external_id": "8860a6b4-1235-451c-aba2-a3129c38c0fc",
                                     "name": "test2",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample2",
                                     "public_name": "Public2",
+                                    "sanger_sample_id": "sample2",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier2",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor2",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1235",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                         ],
@@ -297,45 +307,47 @@ def test_output_traction_message_can_generate_payload_for_multiple_plates():
                             {
                                 "position": "B1",
                                 "request": {
+                                    "cost_code": "S1234",
+                                    "estimate_of_gb_required": None,
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S1234",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1236",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor3",
                                     "external_id": "8860a6b4-1236-451c-aba2-a3129c38c0fc",
                                     "name": "test3",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample3",
                                     "public_name": "Public3",
+                                    "sanger_sample_id": "sample3",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier1",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor3",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1236",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                             {
                                 "position": "C1",
                                 "request": {
+                                    "cost_code": "S4567",
+                                    "estimate_of_gb_required": "987,654,321",
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S4567",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1237",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor4",
                                     "external_id": "8860a6b4-1237-451c-aba2-a3129c38c0fc",
                                     "name": "test4",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample4",
                                     "public_name": "Public4",
+                                    "sanger_sample_id": "sample4",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier2",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor4",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1237",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                         ],
@@ -352,44 +364,46 @@ def test_output_traction_message_can_generate_payload_for_ont_library_types():
     instance = OutputTractionMessage()
 
     request = instance.create_request()
+    request.accession_number = "AN1234"
     request.container_barcode = "1"
-    request.container_type = "wells"
     request.container_location = "A1"
-    request.library_type = "ONT_mylib"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public1"
+    request.container_type = "wells"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor1"
+    request.genome_size = None
+    request.library_type = "ONT_mylib"
     request.priority_level = "Medium"
+    request.public_name = "Public1"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample1"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor1"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1234"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1235"
     request.container_barcode = "1"
-    request.container_type = "wells"
     request.container_location = "B1"
-    request.library_type = "ONT_mylib"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public2"
+    request.container_type = "wells"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor2"
+    request.genome_size = None
+    request.library_type = "ONT_mylib"
     request.priority_level = None
+    request.public_name = "Public2"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample2"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor2"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1235"
-    request.date_of_sample_collection = my_date
 
     assert instance.payload() == {
         "data": {
@@ -404,47 +418,49 @@ def test_output_traction_message_can_generate_payload_for_ont_library_types():
                             {
                                 "position": "A1",
                                 "request": {
-                                    "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
-                                    "library_type": "ONT_mylib",
                                     "cost_code": "S1234",
                                     "data_type": "basecalls",
+                                    "estimate_of_gb_required": None,
+                                    "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
+                                    "library_type": "ONT_mylib",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1234",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor1",
                                     "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": "Medium",
-                                    "sanger_sample_id": "sample1",
                                     "public_name": "Public1",
+                                    "sanger_sample_id": "sample1",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier1",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor1",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1234",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                             {
                                 "position": "B1",
                                 "request": {
-                                    "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
-                                    "library_type": "ONT_mylib",
                                     "cost_code": "S4567",
                                     "data_type": "basecalls",
+                                    "estimate_of_gb_required": None,
+                                    "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
+                                    "library_type": "ONT_mylib",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1235",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor2",
                                     "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample2",
                                     "public_name": "Public2",
+                                    "sanger_sample_id": "sample2",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier2",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor2",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1235",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                         ],
@@ -461,42 +477,44 @@ def test_output_traction_message_can_generate_payload_for_tubes():
     instance = OutputTractionMessage()
 
     request = instance.create_request()
+    request.accession_number = "AN1234"
     request.container_barcode = "1"
     request.container_type = "tubes"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public1"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor1"
+    request.genome_size = "123,456,789"
+    request.library_type = "library"
     request.priority_level = "High"
+    request.public_name = "Public1"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample1"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor1"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1234"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1235"
     request.container_barcode = "1"
     request.container_type = "tubes"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public2"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor2"
+    request.genome_size = "987,654,321"
+    request.library_type = "library"
     request.priority_level = "Low"
+    request.public_name = "Public2"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-82e2-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample2"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor2"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1235"
-    request.date_of_sample_collection = my_date
 
     assert instance.payload() == {
         "data": {
@@ -509,46 +527,48 @@ def test_output_traction_message_can_generate_payload_for_tubes():
                         "barcode": "1",
                         "type": "tubes",
                         "request": {
+                            "cost_code": "S1234",
+                            "estimate_of_gb_required": "123,456,789",
                             "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                             "library_type": "library",
-                            "cost_code": "S1234",
                         },
                         "sample": {
+                            "accession_number": "AN1234",
+                            "country_of_origin": "United Kingdom",
+                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                            "donor_id": "donor1",
                             "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                             "name": "test1",
-                            "species": "test " "species",
                             "priority_level": "High",
-                            "sanger_sample_id": "sample1",
                             "public_name": "Public1",
+                            "sanger_sample_id": "sample1",
+                            "species": "test " "species",
                             "supplier_name": "supplier1",
                             "taxon_id": "9606",
-                            "donor_id": "donor1",
-                            "country_of_origin": "United Kingdom",
-                            "accession_number": "AN1234",
-                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                         },
                     },
                     {
                         "barcode": "1",
                         "type": "tubes",
                         "request": {
+                            "cost_code": "S4567",
+                            "estimate_of_gb_required": "987,654,321",
                             "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                             "library_type": "library",
-                            "cost_code": "S4567",
                         },
                         "sample": {
+                            "accession_number": "AN1235",
+                            "country_of_origin": "United Kingdom",
+                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                            "donor_id": "donor2",
                             "external_id": "8860a6b4-82e2-451c-aba2-a3129c38c0fc",
                             "name": "test1",
-                            "species": "test " "species",
                             "priority_level": "Low",
-                            "sanger_sample_id": "sample2",
                             "public_name": "Public2",
+                            "sanger_sample_id": "sample2",
+                            "species": "test " "species",
                             "supplier_name": "supplier2",
                             "taxon_id": "9606",
-                            "donor_id": "donor2",
-                            "country_of_origin": "United Kingdom",
-                            "accession_number": "AN1235",
-                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                         },
                     },
                 ],
@@ -562,82 +582,86 @@ def test_output_traction_message_can_generate_payload_for_mix_of_plate_and_tubes
     instance = OutputTractionMessage()
 
     request = instance.create_request()
+    request.accession_number = "AN1234"
     request.container_barcode = "123"
-    request.container_type = "wells"
     request.container_location = "A1"
-    request.library_type = "library"
-    request.sample_name = "test1"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1234-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public1"
+    request.container_type = "wells"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor1"
+    request.genome_size = "123,456,789"
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public1"
+    request.sample_name = "test1"
+    request.sample_uuid = "8860a6b4-1234-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample1"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier1"
     request.taxon_id = "9606"
-    request.donor_id = "donor1"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1234"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1235"
     request.container_barcode = "123"
-    request.container_type = "wells"
     request.container_location = "B1"
-    request.library_type = "library"
-    request.sample_name = "test2"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1235-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public2"
+    request.container_type = "wells"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor2"
+    request.genome_size = None
+    request.library_type = "library"
     request.priority_level = None
+    request.public_name = "Public2"
+    request.sample_name = "test2"
+    request.sample_uuid = "8860a6b4-1235-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample2"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier2"
     request.taxon_id = "9606"
-    request.donor_id = "donor2"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1235"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1236"
     request.container_barcode = "987"
     request.container_type = "tubes"
-    request.library_type = "library"
-    request.sample_name = "test3"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1236-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public3"
     request.cost_code = "S1234"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor3"
+    request.genome_size = None
+    request.library_type = "library"
     request.priority_level = "High"
+    request.public_name = "Public3"
+    request.sample_name = "test3"
+    request.sample_uuid = "8860a6b4-1236-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample3"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier3"
     request.taxon_id = "9606"
-    request.donor_id = "donor3"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1236"
-    request.date_of_sample_collection = my_date
 
     request = instance.create_request()
+    request.accession_number = "AN1237"
     request.container_barcode = "876"
     request.container_type = "tubes"
-    request.library_type = "library"
-    request.sample_name = "test4"
-    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
-    request.sample_uuid = "8860a6b4-1237-451c-aba2-a3129c38c0fc"
-    request.species = "test species"
-    request.public_name = "Public4"
     request.cost_code = "S4567"
+    request.country_of_origin = "United Kingdom"
+    request.date_of_sample_collection = my_date
+    request.donor_id = "donor4"
+    request.genome_size = "987,654,321"
+    request.library_type = "library"
     request.priority_level = "Low"
+    request.public_name = "Public4"
+    request.sample_name = "test4"
+    request.sample_uuid = "8860a6b4-1237-451c-aba2-a3129c38c0fc"
     request.sanger_sample_id = "sample4"
+    request.species = "test species"
+    request.study_uuid = "dd490ee5-fd1d-456d-99fd-eb9d3861e014"
     request.supplier_name = "supplier4"
     request.taxon_id = "9606"
-    request.donor_id = "donor4"
-    request.country_of_origin = "United Kingdom"
-    request.accession_number = "AN1237"
-    request.date_of_sample_collection = my_date
 
     assert instance.payload() == {
         "data": {
@@ -652,45 +676,47 @@ def test_output_traction_message_can_generate_payload_for_mix_of_plate_and_tubes
                             {
                                 "position": "A1",
                                 "request": {
+                                    "cost_code": "S1234",
+                                    "estimate_of_gb_required": "123,456,789",
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S1234",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1234",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor1",
                                     "external_id": "8860a6b4-1234-451c-aba2-a3129c38c0fc",
                                     "name": "test1",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample1",
                                     "public_name": "Public1",
+                                    "sanger_sample_id": "sample1",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier1",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor1",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1234",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                             {
                                 "position": "B1",
                                 "request": {
+                                    "cost_code": "S4567",
+                                    "estimate_of_gb_required": None,
                                     "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                                     "library_type": "library",
-                                    "cost_code": "S4567",
                                 },
                                 "sample": {
+                                    "accession_number": "AN1235",
+                                    "country_of_origin": "United Kingdom",
+                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                                    "donor_id": "donor2",
                                     "external_id": "8860a6b4-1235-451c-aba2-a3129c38c0fc",
                                     "name": "test2",
-                                    "species": "test " "species",
                                     "priority_level": None,
-                                    "sanger_sample_id": "sample2",
                                     "public_name": "Public2",
+                                    "sanger_sample_id": "sample2",
+                                    "species": "test " "species",
                                     "supplier_name": "supplier2",
                                     "taxon_id": "9606",
-                                    "donor_id": "donor2",
-                                    "country_of_origin": "United Kingdom",
-                                    "accession_number": "AN1235",
-                                    "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                                 },
                             },
                         ],
@@ -701,46 +727,48 @@ def test_output_traction_message_can_generate_payload_for_mix_of_plate_and_tubes
                         "barcode": "987",
                         "type": "tubes",
                         "request": {
+                            "cost_code": "S1234",
+                            "estimate_of_gb_required": None,
                             "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                             "library_type": "library",
-                            "cost_code": "S1234",
                         },
                         "sample": {
+                            "accession_number": "AN1236",
+                            "country_of_origin": "United Kingdom",
+                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                            "donor_id": "donor3",
                             "external_id": "8860a6b4-1236-451c-aba2-a3129c38c0fc",
                             "name": "test3",
-                            "species": "test " "species",
                             "priority_level": "High",
-                            "sanger_sample_id": "sample3",
                             "public_name": "Public3",
+                            "sanger_sample_id": "sample3",
+                            "species": "test " "species",
                             "supplier_name": "supplier3",
                             "taxon_id": "9606",
-                            "donor_id": "donor3",
-                            "country_of_origin": "United Kingdom",
-                            "accession_number": "AN1236",
-                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                         },
                     },
                     {
                         "barcode": "876",
                         "type": "tubes",
                         "request": {
+                            "cost_code": "S4567",
+                            "estimate_of_gb_required": "987,654,321",
                             "external_study_id": "dd490ee5-fd1d-456d-99fd-eb9d3861e014",
                             "library_type": "library",
-                            "cost_code": "S4567",
                         },
                         "sample": {
+                            "accession_number": "AN1237",
+                            "country_of_origin": "United Kingdom",
+                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
+                            "donor_id": "donor4",
                             "external_id": "8860a6b4-1237-451c-aba2-a3129c38c0fc",
                             "name": "test4",
-                            "species": "test " "species",
                             "priority_level": "Low",
-                            "sanger_sample_id": "sample4",
                             "public_name": "Public4",
+                            "sanger_sample_id": "sample4",
+                            "species": "test " "species",
                             "supplier_name": "supplier4",
                             "taxon_id": "9606",
-                            "donor_id": "donor4",
-                            "country_of_origin": "United Kingdom",
-                            "accession_number": "AN1237",
-                            "date_of_sample_collection": my_date.strftime("%Y-%m-%d"),
                         },
                     },
                 ],

--- a/tests/processors/test_create_labware_processor.py
+++ b/tests/processors/test_create_labware_processor.py
@@ -102,16 +102,16 @@ def test_create_labware_processor_with_invalid_input_triggers_error(
                                 ),
                             },
                             {
-                                "typeId": 7,
-                                "field": "location",
-                                "origin": "sample",
-                                "description": 'Not valid location, instance: "Location", text: "input: A001"',
-                            },
-                            {
                                 "typeId": 2,
                                 "field": "final_nano_drop",
                                 "origin": "sample",
                                 "description": 'Not string, instance: "FinalNanoDrop"',
+                            },
+                            {
+                                "typeId": 7,
+                                "field": "location",
+                                "origin": "sample",
+                                "description": 'Not valid location, instance: "Location", text: "input: A001"',
                             },
                             {
                                 "typeId": 7,

--- a/tol_lab_share/message_properties/definitions/labware.py
+++ b/tol_lab_share/message_properties/definitions/labware.py
@@ -91,24 +91,25 @@ class Labware(MessageProperty):
 
         for sample in self.properties("samples"):
             request = message.create_request()
-            request.cost_code = sample.properties("cost_code").value
-            request.study_uuid = sample.properties("study_uuid").value
-            request.sample_name = sample.properties("sanger_sample_id").value
-            request.public_name = sample.properties("public_name").value
-            request.sample_uuid = sample.properties("uuid").value
-            request.library_type = sample.properties("library_type").value
-            request.species = sample.properties("scientific_name").value
+            request.accession_number = sample.properties("accession_number").value
             request.container_barcode = self.properties("barcode").value
             request.container_location = sample.properties("location").value
             request.container_type = self.traction_container_type()
-            request.priority_level = sample.properties("priority_level").value
-            request.taxon_id = sample.properties("taxon_id").value
-            request.sanger_sample_id = sample.properties("sanger_sample_id").value
-            request.donor_id = sample.properties("donor_id").value
+            request.cost_code = sample.properties("cost_code").value
             request.country_of_origin = sample.properties("country_of_origin").value
-            request.accession_number = sample.properties("accession_number").value
-            request.supplier_name = sample.properties("supplier_sample_name").value
             request.date_of_sample_collection = sample.properties("collection_date").value
+            request.donor_id = sample.properties("donor_id").value
+            request.genome_size = sample.properties("genome_size").value
+            request.library_type = sample.properties("library_type").value
+            request.priority_level = sample.properties("priority_level").value
+            request.public_name = sample.properties("public_name").value
+            request.sample_name = sample.properties("sanger_sample_id").value
+            request.sample_uuid = sample.properties("uuid").value
+            request.sanger_sample_id = sample.properties("sanger_sample_id").value
+            request.species = sample.properties("scientific_name").value
+            request.study_uuid = sample.properties("study_uuid").value
+            request.supplier_name = sample.properties("supplier_sample_name").value
+            request.taxon_id = sample.properties("taxon_id").value
 
     @add_to_message_property.register
     def _(self, message: TractionQcMessage) -> None:

--- a/tol_lab_share/message_properties/definitions/sample.py
+++ b/tol_lab_share/message_properties/definitions/sample.py
@@ -68,39 +68,34 @@ class Sample(MessageProperty):
     def __init__(self, input: Any):
         super().__init__(input)
 
-        self.add_property("cost_code", CostCode(DictInput(input, SAMPLE_COST_CODE)))
-        self.add_property("study_uuid", Uuid(DictInput(input, SAMPLE_STUDY_UUID)))
+        self.add_property("accession_number", AccessionNumber(DictInput(input, SAMPLE_ACCESSION_NUMBER)))
+        self.add_property("collection_date", DateUtc(DictInput(input, SAMPLE_COLLECTION_DATE)))
         self.add_property("common_name", CommonName(DictInput(input, SAMPLE_COMMON_NAME)))
         self.add_property("concentration", Concentration(DictInput(input, SAMPLE_CONCENTRATION)))
-        self.add_property("volume", Volume(DictInput(input, SAMPLE_VOLUME)))
-        self.add_property(
-            "country_of_origin",
-            CountryOfOrigin(DictInput(input, SAMPLE_COUNTRY_OF_ORIGIN)),
-        )
+        self.add_property("cost_code", CostCode(DictInput(input, SAMPLE_COST_CODE)))
+        self.add_property("country_of_origin", CountryOfOrigin(DictInput(input, SAMPLE_COUNTRY_OF_ORIGIN)))
+        self.add_property("date_submitted_utc", DateUtc(DictInput(input, DATE_SUBMITTED_UTC)))
         self.add_property("donor_id", DonorId(DictInput(input, SAMPLE_DONOR_ID)))
-        self.add_property("taxon_id", TaxonId(DictInput(input, SAMPLE_TAXON_ID)))
+        self.add_property("final_nano_drop_230", FinalNanoDrop230(DictInput(input, FINAL_NANODROP_230)))
+        self.add_property("final_nano_drop_280", FinalNanoDrop280(DictInput(input, FINAL_NANODROP_280)))
+        self.add_property("final_nano_drop", FinalNanoDrop(DictInput(input, FINAL_NANODROP)))
+        self.add_property("genome_size", GenomeSize(DictInput(input, SAMPLE_GENOME_SIZE)))
         self.add_property("library_type", LibraryType(DictInput(input, SAMPLE_LIBRARY_TYPE)))
         self.add_property("location", Location(DictInput(input, SAMPLE_LOCATION)))
+        self.add_property("post_spri_concentration", PostSPRIConcentration(DictInput(input, POST_SPRI_CONCENTRATION)))
+        self.add_property("post_spri_volume", PostSPRIVolume(DictInput(input, POST_SPRI_VOLUME)))
+        self.add_property("priority_level", PriorityLevel(DictInput(input, PRIORITY_LEVEL)))
         self.add_property("public_name", PublicName(DictInput(input, SAMPLE_PUBLIC_NAME)))
         self.add_property("sanger_sample_id", SangerSampleId(DictInput(input, SAMPLE_SANGER_SAMPLE_ID)))
         self.add_property(
-            "scientific_name",
-            ScientificNameFromTaxonId(TaxonId(DictInput(input, SAMPLE_SANGER_TAXON_ID))),
+            "scientific_name", ScientificNameFromTaxonId(TaxonId(DictInput(input, SAMPLE_SANGER_TAXON_ID)))
         )
-        self.add_property("uuid", Uuid(DictInput(input, SAMPLE_SANGER_UUID)))
-        self.add_property("accession_number", AccessionNumber(DictInput(input, SAMPLE_ACCESSION_NUMBER)))
-        self.add_property("genome_size", GenomeSize(DictInput(input, SAMPLE_GENOME_SIZE)))
-        self.add_property("collection_date", DateUtc(DictInput(input, SAMPLE_COLLECTION_DATE)))
-        self.add_property("supplier_sample_name", SupplierSampleName(DictInput(input, SUPPLIER_SAMPLE_NAME)))
-
         self.add_property(
             "sheared_femto_fragment_size", ShearedFemtoFragmentSize(DictInput(input, SHEARED_FEMTO_FRAGMENT_SIZE))
         )
-        self.add_property("post_spri_concentration", PostSPRIConcentration(DictInput(input, POST_SPRI_CONCENTRATION)))
-        self.add_property("post_spri_volume", PostSPRIVolume(DictInput(input, POST_SPRI_VOLUME)))
-        self.add_property("final_nano_drop_280", FinalNanoDrop280(DictInput(input, FINAL_NANODROP_280)))
-        self.add_property("final_nano_drop_230", FinalNanoDrop230(DictInput(input, FINAL_NANODROP_230)))
-        self.add_property("final_nano_drop", FinalNanoDrop(DictInput(input, FINAL_NANODROP)))
         self.add_property("shearing_qc_comments", ShearingAndQCComments(DictInput(input, SHEARING_QC_COMMENTS)))
-        self.add_property("date_submitted_utc", DateUtc(DictInput(input, DATE_SUBMITTED_UTC)))
-        self.add_property("priority_level", PriorityLevel(DictInput(input, PRIORITY_LEVEL)))
+        self.add_property("study_uuid", Uuid(DictInput(input, SAMPLE_STUDY_UUID)))
+        self.add_property("supplier_sample_name", SupplierSampleName(DictInput(input, SUPPLIER_SAMPLE_NAME)))
+        self.add_property("taxon_id", TaxonId(DictInput(input, SAMPLE_TAXON_ID)))
+        self.add_property("uuid", Uuid(DictInput(input, SAMPLE_SANGER_UUID)))
+        self.add_property("volume", Volume(DictInput(input, SAMPLE_VOLUME)))

--- a/tol_lab_share/messages/output_traction_message.py
+++ b/tol_lab_share/messages/output_traction_message.py
@@ -29,6 +29,7 @@ class OutputTractionMessageRequest:
         self.country_of_origin: str | None = None
         self.date_of_sample_collection: datetime | None = None
         self.donor_id: str | None = None
+        self.genome_size: str | None = None
         self.library_type: str | None = None
         self.priority_level: str | None = None
         self.public_name: str | None = None
@@ -72,9 +73,10 @@ class Serializer:
             dict[str, Any]: A dictionary containing the Traction "request" payload for the request.
         """
         request_payload = {
-            "library_type": request.library_type,
-            "external_study_id": request.study_uuid,
             "cost_code": request.cost_code,
+            "estimate_of_gb_required": request.genome_size,
+            "external_study_id": request.study_uuid,
+            "library_type": request.library_type,
         }
 
         if request.library_type and ("ONT" in request.library_type):
@@ -97,18 +99,18 @@ class Serializer:
             collection_date = request.date_of_sample_collection.strftime("%Y-%m-%d")
 
         return {
-            "name": request.sample_name,
-            "external_id": request.sample_uuid,
-            "species": request.species,
-            "priority_level": request.priority_level,
-            "sanger_sample_id": request.sanger_sample_id,
-            "supplier_name": request.supplier_name,
-            "public_name": request.public_name,
-            "taxon_id": request.taxon_id,
-            "donor_id": request.donor_id,
-            "country_of_origin": request.country_of_origin,
             "accession_number": request.accession_number,
+            "country_of_origin": request.country_of_origin,
             "date_of_sample_collection": collection_date,
+            "donor_id": request.donor_id,
+            "external_id": request.sample_uuid,
+            "name": request.sample_name,
+            "priority_level": request.priority_level,
+            "public_name": request.public_name,
+            "sanger_sample_id": request.sanger_sample_id,
+            "species": request.species,
+            "supplier_name": request.supplier_name,
+            "taxon_id": request.taxon_id,
         }
 
 


### PR DESCRIPTION
Closes #66 

#### Changes proposed in this pull request

- Accept genome size into the traction requests.
- Compose the value as `estimate_of_bp_required` in the API body.
- Update tests to confirm behaviour.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  