### PR TITLE
Y24-016: Raise TransientRabbitError if the Traction API requests fail

### DIFF
--- a/tol_lab_share/messages/traction/reception_message.py
+++ b/tol_lab_share/messages/traction/reception_message.py
@@ -1,9 +1,11 @@
 from functools import singledispatchmethod
 import itertools
+import logging
 from typing import Callable, Any
 from json import dumps
 from datetime import datetime
 from requests import post, codes
+from lab_share_lib.exceptions import TransientRabbitError
 from tol_lab_share.messages.properties import MessageProperty
 from tol_lab_share.messages.properties.simple import Value
 from tol_lab_share.constants import (
@@ -14,6 +16,8 @@ from tol_lab_share import error_codes
 from tol_lab_share.error_codes import ErrorCode
 from tol_lab_share.helpers import get_config
 from tol_lab_share.messages.rabbit.published import CreateLabwareFeedbackMessage
+
+logger = logging.getLogger(__name__)
 
 
 class TractionReceptionMessageRequest:
@@ -317,7 +321,13 @@ class TractionReceptionMessage(MessageProperty):
         """
         headers = {"Content-type": "application/vnd.api+json", "Accept": "application/vnd.api+json"}
 
-        r = post(url, headers=headers, data=dumps(self.payload()), verify=self._validate_certificates)
+        try:
+            r = post(url, headers=headers, data=dumps(self.payload()), verify=self._validate_certificates)
+        except Exception as ex:
+            logger.critical(f"Error submitting {self.__class__.__name__} to the Traction API.")
+            logger.exception(ex)
+
+            raise TransientRabbitError(f"There was an error POSTing the {self.__class__.__name__} to the Traction API.")
 
         self._sent = r.status_code == codes.created
         if not self._sent:


### PR DESCRIPTION
Closes #70 

#### Changes proposed in this pull request

- Check for exceptions when calling `post` for the Traction API endpoints and raise a `TransientRabbitError` to instruct the consumer to pause 30 seconds before trying to reconnect.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  