### PR TITLE
Y24-019: Design an AVRO schema for Pool XP tubes going to Traction

### DIFF
--- a/schemas/bioscan-pool-xp-to-traction/1-bioscan-pool-xp-to-traction.avsc
+++ b/schemas/bioscan-pool-xp-to-traction/1-bioscan-pool-xp-to-traction.avsc
@@ -1,0 +1,126 @@
+{
+    "namespace": "uk.ac.sanger.psd",
+    "type": "record",
+    "name": "ExportPoolXPTubeToTraction",
+    "doc": "A message to pass all the metadata required to export a Bioscan Pool XP tube to Traction.",
+    "fields": [
+        {
+            "name": "messageUuid",
+            "doc": "The UTF-8 byte encoded unique message ID.",
+            "type": {
+                "name": "version4MessageUuid",
+                "type": "fixed",
+                "size": 36
+            }
+        },
+        {
+            "name": "messageCreateDateUtc",
+            "doc": "Date (UTC) that the message was created. Represented as milliseconds since the Unix epoch.",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            }
+        },
+        {
+            "name": "tubeBarcode",
+            "type": "string",
+            "doc": "The barcode for the tube."
+        },
+        {
+            "name": "library",
+            "doc": "Properties of the library associated with the tube.",
+            "type": {
+                "name": "Library",
+                "type": "record",
+                "doc": "Library properties.",
+                "fields": [
+                    {
+                        "name": "volume",
+                        "type": "float",
+                        "doc": "The volume of the library in µL. Must be greater than or equal to 0."
+                    },
+                    {
+                        "name": "concentration",
+                        "type": "float",
+                        "doc": "The concentration of the library in ng/µL. Must be greater than or equal to 0."
+                    },
+                    {
+                        "name": "boxBarcode",
+                        "type": "string",
+                        "doc": "The template prep kit box barcode."
+                    },
+                    {
+                        "name": "insertSize",
+                        "type": [
+                            "null",
+                            "int"
+                        ],
+                        "default": null,
+                        "doc": "(Optional) The library insert size."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "request",
+            "doc": "Properties of the request associated with the tube.",
+            "type": {
+                "name": "Request",
+                "type": "record",
+                "doc": "Request properties.",
+                "fields": [
+                    {
+                        "name": "costCode",
+                        "type": "string",
+                        "doc": "The cost code for billing purposes."
+                    },
+                    {
+                        "name": "genomeSize",
+                        "type": [
+                            "null",
+                            "string"
+                        ],
+                        "default": null,
+                        "doc": "(Optional) The size of the genome, to be recorded as estimate_of_gb_required."
+                    },
+                    {
+                        "name": "libraryType",
+                        "type": "string",
+                        "doc": "The type of library for the request. Must match one of the options in Traction."
+                    },
+                    {
+                        "name": "studyUuid",
+                        "type": "version4MessageUuid",
+                        "doc": "The UTF-8 byte encoded unique study UUID the request belongs to."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sample",
+            "doc": "Properties of the sample contained in the tube.",
+            "type": {
+                "name": "Sample",
+                "type": "record",
+                "doc": "Sample properties.",
+                "fields": [
+                    {
+                        "name": "sampleName",
+                        "type": "string",
+                        "doc": "The name of the sample - displayed in Traction and filterable so might be used to store an identifier."
+                    },
+                    {
+                        "name": "sampleUuid",
+                        "type": "string",
+                        "doc": "The UTF-8 byte encoded unique sample UUID the request belongs to. Will be stored as external_id in Traction."
+                    },
+                    {
+                        "name": "speciesName",
+                        "type": "string",
+                        "doc": "The name of the species the sample was collected from."
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Create first attempt at an Avro schema for Pool XP tubes going to Traction

Closes #71 

#### Changes proposed in this pull request

- Add the new schema

I had originally meant to include some values that turn out to be optional for samples, but then I realised there are a lot of them and most are not being used in Traction anyway.  The ones I was including seemed quite arbitrary and I'm not sure which might be needed for Pool XP tubes.  So I've only included the core values in this schema.  We can add more if we need to.  I think it would be good if we could see an example of how they've already added samples/libraries to Traction or find out what they need to be represented on Traction as I still feel I'm plucking ideas out of thin air.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  